### PR TITLE
Add `org_name` in `token` and `permission_set` path

### DIFF
--- a/github/backend_test.go
+++ b/github/backend_test.go
@@ -122,6 +122,16 @@ func TestBackend_Config(t *testing.T) {
 			},
 		},
 		{
+			name: "Organization",
+			new: []byte(fmt.Sprintf(`{"%s":%d, "%s":"%s"}`,
+				keyAppID, testAppID1, keyOrgName, testOrgName1)),
+			exp: &Config{
+				AppID:   testAppID1,
+				OrgName: testOrgName1,
+				BaseURL: githubPublicAPI,
+			},
+		},
+		{
 			name:        "FailedStorage",
 			failStorage: []failVerb{failVerbRead, failVerbPut, failVerbList, failVerbDelete},
 			err:         errors.New(fmtErrConfRetrieval),

--- a/github/client.go
+++ b/github/client.go
@@ -137,6 +137,7 @@ func (c *Client) Token(ctx context.Context, opts *tokenOptions) (*logical.Respon
 	}
 
 	if opts.Organization != "" && c.config.InsID == 0 {
+		c.config.OrgName = opts.Organization
 		insID, err := c.getInstallationID()
 		if err != nil {
 			return nil, err

--- a/github/client.go
+++ b/github/client.go
@@ -106,6 +106,9 @@ type tokenOptions struct {
 	RepositoryIDs []int `json:"repository_ids,omitempty"`
 	// Repositories are the repository names that the token can access.
 	Repositories []string `json:"repositories,omitempty"`
+
+	//Organization name where access token should be granted.
+	Organization string `json:"-"`
 }
 
 // statusCode models an HTTP response code.
@@ -131,6 +134,14 @@ func (c *Client) Token(ctx context.Context, opts *tokenOptions) (*logical.Respon
 		if err := json.NewEncoder(body).Encode(opts); err != nil {
 			return nil, err
 		}
+	}
+
+	if opts.Organization != "" && c.config.InsID == 0 {
+		insID, err := c.getInstallationID()
+		if err != nil {
+			return nil, err
+		}
+		c.config.InsID = insID
 	}
 
 	tokenUrl, err := c.url()

--- a/github/client_test.go
+++ b/github/client_test.go
@@ -75,6 +75,16 @@ func TestNewClient(t *testing.T) {
 			},
 			err: errors.New("parse"),
 		},
+		{
+			name: "OrgName",
+			conf: &Config{
+				AppID:   testAppID1,
+				OrgName: testOrgName1,
+				PrvKey:  testPrvKeyValid,
+				BaseURL: testBaseURLValid,
+			},
+			err: errors.New("integrations"),
+		},
 	}
 
 	for _, tc := range cases {
@@ -195,6 +205,16 @@ func TestClient_Token(t *testing.T) {
 			err: errUnableToDecodeAccessTokenRes,
 		},
 		{
+			name: "ErrorInError",
+			ctx:  context.Background(),
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Helper()
+				w.Header().Set("Content-Length", "1")
+				w.WriteHeader(http.StatusForbidden)
+			}),
+			err: errUnableToCreateAccessToken,
+		},
+		{
 			name: "EmptyResponse",
 			ctx:  context.Background(),
 			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -205,6 +225,19 @@ func TestClient_Token(t *testing.T) {
 		},
 		{
 			name: "4xxResponse",
+			ctx:  context.Background(),
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Helper()
+				// 422 is the most likely GitHub Apps API 4xx response (when
+				// presented with valid auth) and it occurs when the user has
+				// requested token permissions or repositories the installation
+				// does not have scope over.
+				w.WriteHeader(http.StatusUnprocessableEntity)
+			}),
+			err: errUnableToCreateAccessToken,
+		},
+		{
+			name: "OrgInTokenOpts",
 			ctx:  context.Background(),
 			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				t.Helper()
@@ -296,6 +329,16 @@ func TestClient_RevokeToken(t *testing.T) {
 			err:  errUnableToBuildAccessTokenRevReq,
 		},
 		{
+			name: "ErrorInError",
+			ctx:  context.Background(),
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Helper()
+				w.Header().Set("Content-Length", "1")
+				w.WriteHeader(http.StatusForbidden)
+			}),
+			err: errUnableToRevokeAccessToken,
+		},
+		{
 			name: "401Response",
 			ctx:  context.Background(),
 			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -343,6 +386,192 @@ func TestClient_RevokeToken(t *testing.T) {
 			}
 
 			assert.DeepEqual(t, res, tc.res)
+		})
+	}
+}
+
+func TestClient_Organization(t *testing.T) {
+	var cases = []struct {
+		name    string
+		handler http.HandlerFunc
+		ctx     context.Context
+		err     error
+	}{
+		{
+			name: "HappyPath",
+			ctx:  context.Background(),
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Helper()
+
+				assert.Equal(t, r.Method, http.MethodGet)
+				assert.Equal(t, r.URL.Path, "/app/installations")
+				assert.Assert(t, r.Header.Get("Authorization") != "")
+
+				w.Header().Set("Content-Type", "application/json")
+				body, _ := json.Marshal([]map[string]interface{}{
+					{
+						"id": testInsID1,
+						"account": map[string]interface{}{
+							"login": testOrgName1,
+						},
+					},
+				})
+				w.WriteHeader(http.StatusOK)
+				w.Write(body)
+			}),
+		},
+		{
+			name: "ZeroPath",
+			ctx:  context.Background(),
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Helper()
+
+				assert.Equal(t, r.Method, http.MethodGet)
+				assert.Equal(t, r.URL.Path, "/app/installations")
+				assert.Assert(t, r.Header.Get("Authorization") != "")
+
+				w.Header().Set("Content-Type", "application/json")
+				body, _ := json.Marshal([]map[string]interface{}{
+					{
+						"id": testInsID1,
+						"account": map[string]interface{}{
+							"login": testOrgName2,
+						},
+					},
+				})
+				w.WriteHeader(http.StatusOK)
+				w.Write(body)
+			}),
+			err: errors.New("application"),
+		},
+		{
+			name: "EmptyResponse",
+			ctx:  context.Background(),
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Helper()
+				w.WriteHeader(http.StatusOK)
+			}),
+			err: errUnableToDecodeIntegrationRes,
+		},
+		{
+			name: "ErrorInError",
+			ctx:  context.Background(),
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Helper()
+				w.Header().Set("Content-Length", "1")
+				w.WriteHeader(http.StatusForbidden)
+			}),
+			err: errUnableToGetIntegrations,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ts := httptest.NewServer(tc.handler)
+			defer ts.Close()
+
+			_, err := NewClient(&Config{
+				AppID:   testAppID1,
+				OrgName: testOrgName1,
+				PrvKey:  testPrvKeyValid,
+				BaseURL: ts.URL,
+			})
+
+			if tc.err != nil {
+				assert.ErrorContains(t, err, tc.err.Error())
+			} else {
+				assert.NilError(t, err)
+			}
+		})
+	}
+}
+
+func TestClient_TokenEmptyConfig(t *testing.T) {
+	t.Parallel()
+
+	var cases = []struct {
+		name    string
+		opts    *tokenOptions
+		handler http.HandlerFunc
+		res     *logical.Response
+		ctx     context.Context
+		err     error
+	}{
+		{
+			name: "HappyPathWithOrganization",
+			ctx:  context.Background(),
+			opts: &tokenOptions{
+				Organization: testOrgName1,
+			},
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Helper()
+
+				if r.Method == http.MethodGet && r.URL.Path == "/app/installations" {
+					assert.Assert(t, r.Header.Get("Authorization") != "")
+
+					w.Header().Set("Content-Type", "application/json")
+					body, _ := json.Marshal([]map[string]interface{}{
+						{
+							"id": testInsID1,
+							"account": map[string]interface{}{
+								"login": testOrgName1,
+							},
+						},
+					})
+					w.WriteHeader(http.StatusOK)
+					w.Write(body)
+				} else if r.Method == http.MethodPost && r.URL.Path == fmt.Sprintf("/%s", testPath) {
+					assert.Assert(t, r.Header.Get("Authorization") != "")
+
+					w.Header().Set("Content-Type", "application/json")
+					body, _ := json.Marshal(map[string]interface{}{
+						"token":      testToken,
+						"expires_at": testTokenExp,
+					})
+					w.WriteHeader(http.StatusCreated)
+					w.Write(body)
+				}
+
+			}),
+			res: &logical.Response{
+				Data: map[string]interface{}{
+					"token":      testToken,
+					"expires_at": testTokenExp,
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ts := httptest.NewServer(tc.handler)
+			defer ts.Close()
+
+			client, err := NewClient(&Config{
+				AppID:   testAppID1,
+				PrvKey:  testPrvKeyValid,
+				BaseURL: ts.URL,
+			})
+			assert.NilError(t, err)
+
+			res, err := client.Token(tc.ctx, tc.opts)
+
+			if tc.err != nil {
+				assert.ErrorContains(t, err, tc.err.Error())
+			} else {
+				assert.NilError(t, err)
+			}
+
+			if tc.res != nil && tc.res.Data != nil {
+				assert.Equal(t, res.Data["expires_at"], tc.res.Data["expires_at"])
+				assert.Equal(t, res.Data["token"], tc.res.Data["token"])
+			}
 		})
 	}
 }

--- a/github/client_test.go
+++ b/github/client_test.go
@@ -89,7 +89,7 @@ func TestNewClient(t *testing.T) {
 			} else {
 				assert.NilError(t, err)
 				assert.Assert(t, c != nil)
-				tokenUrl, err := c.url()
+				tokenUrl, err := c.url(tc.conf.InsID)
 				assert.NilError(t, err)
 				assert.Equal(t, tokenUrl.String(), tc.url)
 			}

--- a/github/path_permission_set.go
+++ b/github/path_permission_set.go
@@ -108,6 +108,10 @@ func (b *backend) pathPermissionSet() *framework.Path {
 	return &framework.Path{
 		Pattern: fmt.Sprintf("permissionset/%s", framework.GenericNameRegex("name")),
 		Fields: map[string]*framework.FieldSchema{
+			keyOrgName: {
+				Type:        framework.TypeString,
+				Description: descOrgName,
+			},
 			"name": {
 				Type:        framework.TypeString,
 				Description: "Required. Name of the permission set.",
@@ -232,6 +236,10 @@ func (b *backend) pathPermissionSetCreateUpdate(
 
 	if repos, ok := d.GetOk(keyRepos); ok {
 		ps.TokenOptions.Repositories = repos.([]string)
+	}
+
+	if org, ok := d.GetOk(keyOrgName); ok {
+		ps.TokenOptions.Organization = org.(string)
 	}
 
 	// Save permissions set

--- a/github/path_token.go
+++ b/github/path_token.go
@@ -48,6 +48,10 @@ func (b *backend) pathToken() *framework.Path {
 	return &framework.Path{
 		Pattern: pathPatternToken,
 		Fields: map[string]*framework.FieldSchema{
+			keyOrgName: {
+				Type:        framework.TypeString,
+				Description: descOrgName,
+			},
 			keyRepos: {
 				Type:        framework.TypeCommaStringSlice,
 				Description: descRepos,
@@ -105,6 +109,10 @@ func (b *backend) pathTokenWrite(
 
 	if repos, ok := d.GetOk(keyRepos); ok {
 		opts.Repositories = repos.([]string)
+	}
+
+	if org, ok := d.GetOk(keyOrgName); ok {
+		opts.Organization = org.(string)
 	}
 
 	// Instrument and log the token API call, recording status, duration and

--- a/github/path_token_permission_set.go
+++ b/github/path_token_permission_set.go
@@ -35,6 +35,10 @@ func (b *backend) pathTokenPermissionSet() *framework.Path {
 	return &framework.Path{
 		Pattern: fmt.Sprintf("%s/%s", pathPatternToken, framework.GenericNameRegex("permissionset")),
 		Fields: map[string]*framework.FieldSchema{
+			keyOrgName: {
+				Type:        framework.TypeString,
+				Description: descOrgName,
+			},
 			"permissionset": {
 				Type:        framework.TypeString,
 				Description: "Required. Name of the permission set.",
@@ -79,6 +83,10 @@ func (b *backend) pathTokenPermissionSetWrite(
 	}
 
 	opts := ps.TokenOptions
+
+	if org, ok := d.GetOk(keyOrgName); ok {
+		opts.Organization = org.(string)
+	}
 
 	// Instrument and log the token API call, recording status, duration and
 	// whether any constraints (permissions, repositories, repository IDs) were

--- a/github/path_token_test.go
+++ b/github/path_token_test.go
@@ -150,6 +150,55 @@ func testBackendPathTokenWrite(t *testing.T, op logical.Operation) {
 		assert.Assert(t, is.Nil(r))
 		assert.Assert(t, errors.Is(err, errUnableToCreateAccessToken))
 	})
+
+	t.Run("HappyPathOrgPlusOrg", func(t *testing.T) {
+		t.Parallel()
+
+		b, storage := testBackend(t)
+
+		ts := httptest.NewServer(http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				t.Helper()
+
+				body, _ := json.Marshal(map[string]interface{}{
+					"token":      testToken,
+					"expires_at": testTokenExp,
+				})
+				w.WriteHeader(http.StatusCreated)
+				w.Write(body)
+			}),
+		)
+		defer ts.Close()
+
+		_, err := b.HandleRequest(context.Background(), &logical.Request{
+			Storage:   storage,
+			Operation: logical.CreateOperation,
+			Path:      pathPatternConfig,
+			Data: map[string]interface{}{
+				keyAppID:   testAppID1,
+				keyInsID:   testInsID1,
+				keyPrvKey:  testPrvKeyValid,
+				keyBaseURL: ts.URL,
+			},
+		})
+		assert.NilError(t, err)
+
+		r, err := b.HandleRequest(context.Background(), &logical.Request{
+			Storage:   storage,
+			Operation: op,
+			Path:      pathPatternToken,
+			Data: map[string]interface{}{
+				keyRepos:   []string{testRepo1, testRepo2},
+				keyRepoIDs: []int{testRepoID1, testRepoID2},
+				keyPerms:   testPerms,
+			},
+		})
+		assert.NilError(t, err)
+
+		assert.Assert(t, r != nil)
+		assert.Equal(t, r.Data["expires_at"].(string), testTokenExp)
+		assert.Equal(t, r.Data["token"].(string), testToken)
+	})
 }
 
 func TestBackend_PathTokenWriteRead(t *testing.T) {


### PR DESCRIPTION
Add `org_name` flag in `token` and `permission_set` path

Resolves: #13

```
=== RUN   TestFactory
=== PAUSE TestFactory
=== CONT  TestFactory
--- PASS: TestFactory (0.02s)
=== RUN   TestFactory/HappyPath
=== PAUSE TestFactory/HappyPath
=== CONT  TestFactory/HappyPath
    --- PASS: TestFactory/HappyPath (0.00s)
=== RUN   TestFactory/NilConfig
=== PAUSE TestFactory/NilConfig
=== CONT  TestFactory/NilConfig
    --- PASS: TestFactory/NilConfig (0.00s)
=== RUN   TestBackend_Config
=== PAUSE TestBackend_Config
=== CONT  TestBackend_Config
--- PASS: TestBackend_Config (0.07s)
=== RUN   TestBackend_Config/Empty
=== PAUSE TestBackend_Config/Empty
=== CONT  TestBackend_Config/Empty
    --- PASS: TestBackend_Config/Empty (0.00s)
=== RUN   TestBackend_Config/HappyPath
=== PAUSE TestBackend_Config/HappyPath
=== CONT  TestBackend_Config/HappyPath
    --- PASS: TestBackend_Config/HappyPath (0.00s)
=== RUN   TestBackend_Config/Organization
=== PAUSE TestBackend_Config/Organization
=== CONT  TestBackend_Config/Organization
    --- PASS: TestBackend_Config/Organization (0.00s)
=== RUN   TestBackend_Config/Organization#01
=== PAUSE TestBackend_Config/Organization#01
=== CONT  TestBackend_Config/Organization#01
    --- PASS: TestBackend_Config/Organization#01 (0.00s)
=== RUN   TestBackend_Config/FailedStorage
=== PAUSE TestBackend_Config/FailedStorage
=== CONT  TestBackend_Config/FailedStorage
    --- PASS: TestBackend_Config/FailedStorage (0.00s)
=== RUN   TestBackend_Config/FailedUnmarshal
=== PAUSE TestBackend_Config/FailedUnmarshal
=== CONT  TestBackend_Config/FailedUnmarshal
    --- PASS: TestBackend_Config/FailedUnmarshal (0.00s)
=== RUN   TestBackend_Client
=== PAUSE TestBackend_Client
=== CONT  TestBackend_Client
--- PASS: TestBackend_Client (0.04s)
=== RUN   TestBackend_Client/AllowConcurrentReads
=== PAUSE TestBackend_Client/AllowConcurrentReads
=== CONT  TestBackend_Client/AllowConcurrentReads
    --- PASS: TestBackend_Client/AllowConcurrentReads (0.00s)
=== RUN   TestBackend_Client/ReusesExisting
=== PAUSE TestBackend_Client/ReusesExisting
=== CONT  TestBackend_Client/ReusesExisting
    --- PASS: TestBackend_Client/ReusesExisting (0.00s)
=== RUN   TestBackend_Client/FailedStorage
=== PAUSE TestBackend_Client/FailedStorage
=== CONT  TestBackend_Client/FailedStorage
    --- PASS: TestBackend_Client/FailedStorage (0.00s)
=== RUN   TestBackend_Client/BadConfig
=== PAUSE TestBackend_Client/BadConfig
=== CONT  TestBackend_Client/BadConfig
    --- PASS: TestBackend_Client/BadConfig (0.00s)
=== RUN   TestNewClient
=== PAUSE TestNewClient
=== CONT  TestNewClient
--- PASS: TestNewClient (0.04s)
=== RUN   TestNewClient/Empty
=== PAUSE TestNewClient/Empty
=== CONT  TestNewClient/Empty
    --- PASS: TestNewClient/Empty (0.00s)
=== RUN   TestNewClient/HappyPath
=== PAUSE TestNewClient/HappyPath
=== CONT  TestNewClient/HappyPath
    --- PASS: TestNewClient/HappyPath (0.00s)
=== RUN   TestNewClient/InvalidPrvKey
=== PAUSE TestNewClient/InvalidPrvKey
=== CONT  TestNewClient/InvalidPrvKey
    --- PASS: TestNewClient/InvalidPrvKey (0.00s)
=== RUN   TestNewClient/InvalidBaseURL
=== PAUSE TestNewClient/InvalidBaseURL
=== CONT  TestNewClient/InvalidBaseURL
    --- PASS: TestNewClient/InvalidBaseURL (0.00s)
=== RUN   TestNewClient/OrgName
=== PAUSE TestNewClient/OrgName
=== CONT  TestNewClient/OrgName
    --- PASS: TestNewClient/OrgName (0.45s)
=== RUN   TestClient_Token
=== PAUSE TestClient_Token
=== CONT  TestClient_Token
--- PASS: TestClient_Token (0.04s)
=== RUN   TestClient_Token/HappyPath
=== PAUSE TestClient_Token/HappyPath
=== CONT  TestClient_Token/HappyPath
    --- PASS: TestClient_Token/HappyPath (0.03s)
=== RUN   TestClient_Token/HappyPathWithTokenConstraints
=== PAUSE TestClient_Token/HappyPathWithTokenConstraints
=== CONT  TestClient_Token/HappyPathWithTokenConstraints
    --- PASS: TestClient_Token/HappyPathWithTokenConstraints (0.01s)
=== RUN   TestClient_Token/NilContext
=== PAUSE TestClient_Token/NilContext
=== CONT  TestClient_Token/NilContext
    --- PASS: TestClient_Token/NilContext (0.01s)
=== RUN   TestClient_Token/EOFResponse
=== PAUSE TestClient_Token/EOFResponse
=== CONT  TestClient_Token/EOFResponse
    --- PASS: TestClient_Token/EOFResponse (0.02s)
=== RUN   TestClient_Token/ErrorInError
=== PAUSE TestClient_Token/ErrorInError
=== CONT  TestClient_Token/ErrorInError
    --- PASS: TestClient_Token/ErrorInError (0.02s)
=== RUN   TestClient_Token/EmptyResponse
=== PAUSE TestClient_Token/EmptyResponse
=== CONT  TestClient_Token/EmptyResponse
    --- PASS: TestClient_Token/EmptyResponse (0.04s)
=== RUN   TestClient_Token/4xxResponse
=== PAUSE TestClient_Token/4xxResponse
=== CONT  TestClient_Token/4xxResponse
    --- PASS: TestClient_Token/4xxResponse (0.03s)
=== RUN   TestClient_Token/OrgInTokenOpts
=== PAUSE TestClient_Token/OrgInTokenOpts
=== CONT  TestClient_Token/OrgInTokenOpts
    --- PASS: TestClient_Token/OrgInTokenOpts (0.04s)
=== RUN   TestClient_RevokeToken
=== PAUSE TestClient_RevokeToken
=== CONT  TestClient_RevokeToken
--- PASS: TestClient_RevokeToken (0.04s)
=== RUN   TestClient_RevokeToken/HappyPath
=== PAUSE TestClient_RevokeToken/HappyPath
=== CONT  TestClient_RevokeToken/HappyPath
    --- PASS: TestClient_RevokeToken/HappyPath (0.03s)
=== RUN   TestClient_RevokeToken/NilContext
=== PAUSE TestClient_RevokeToken/NilContext
=== CONT  TestClient_RevokeToken/NilContext
    --- PASS: TestClient_RevokeToken/NilContext (0.00s)
=== RUN   TestClient_RevokeToken/ErrorInError
=== PAUSE TestClient_RevokeToken/ErrorInError
=== CONT  TestClient_RevokeToken/ErrorInError
    --- PASS: TestClient_RevokeToken/ErrorInError (0.01s)
=== RUN   TestClient_RevokeToken/401Response
=== PAUSE TestClient_RevokeToken/401Response
=== CONT  TestClient_RevokeToken/401Response
    --- PASS: TestClient_RevokeToken/401Response (0.03s)
=== RUN   TestClient_RevokeToken/403Response
=== PAUSE TestClient_RevokeToken/403Response
=== CONT  TestClient_RevokeToken/403Response
    --- PASS: TestClient_RevokeToken/403Response (0.03s)
=== RUN   TestClient_Organization
--- PASS: TestClient_Organization (0.00s)
=== RUN   TestClient_Organization/HappyPath
=== PAUSE TestClient_Organization/HappyPath
=== CONT  TestClient_Organization/HappyPath
    --- PASS: TestClient_Organization/HappyPath (0.01s)
=== RUN   TestClient_Organization/ZeroPath
=== PAUSE TestClient_Organization/ZeroPath
=== CONT  TestClient_Organization/ZeroPath
    --- PASS: TestClient_Organization/ZeroPath (0.01s)
=== RUN   TestClient_Organization/EmptyResponse
=== PAUSE TestClient_Organization/EmptyResponse
=== CONT  TestClient_Organization/EmptyResponse
    --- PASS: TestClient_Organization/EmptyResponse (0.01s)
=== RUN   TestClient_Organization/ErrorInError
=== PAUSE TestClient_Organization/ErrorInError
=== CONT  TestClient_Organization/ErrorInError
    --- PASS: TestClient_Organization/ErrorInError (0.01s)
=== RUN   TestClient_TokenEmptyConfig
=== PAUSE TestClient_TokenEmptyConfig
=== CONT  TestClient_TokenEmptyConfig
--- PASS: TestClient_TokenEmptyConfig (0.00s)
=== RUN   TestClient_TokenEmptyConfig/HappyPathWithOrganization
=== PAUSE TestClient_TokenEmptyConfig/HappyPathWithOrganization
=== CONT  TestClient_TokenEmptyConfig/HappyPathWithOrganization
    --- PASS: TestClient_TokenEmptyConfig/HappyPathWithOrganization (0.01s)
=== RUN   TestConfig_Update
=== PAUSE TestConfig_Update
=== CONT  TestConfig_Update
--- PASS: TestConfig_Update (0.04s)
=== RUN   TestConfig_Update/Empty
=== PAUSE TestConfig_Update/Empty
=== CONT  TestConfig_Update/Empty
    --- PASS: TestConfig_Update/Empty (0.00s)
=== RUN   TestConfig_Update/Persists
=== PAUSE TestConfig_Update/Persists
=== CONT  TestConfig_Update/Persists
    --- PASS: TestConfig_Update/Persists (0.00s)
=== RUN   TestConfig_Update/Overwrites
=== PAUSE TestConfig_Update/Overwrites
=== CONT  TestConfig_Update/Overwrites
    --- PASS: TestConfig_Update/Overwrites (0.00s)
=== RUN   TestConfig_Update/OverwritesAndAdds
=== PAUSE TestConfig_Update/OverwritesAndAdds
=== CONT  TestConfig_Update/OverwritesAndAdds
    --- PASS: TestConfig_Update/OverwritesAndAdds (0.00s)
=== RUN   TestConfig_Update/BaseURLInvalid
=== PAUSE TestConfig_Update/BaseURLInvalid
=== CONT  TestConfig_Update/BaseURLInvalid
    --- PASS: TestConfig_Update/BaseURLInvalid (0.00s)
=== RUN   TestConfig_Update/PrivateKeyNotPEMEncoded
=== PAUSE TestConfig_Update/PrivateKeyNotPEMEncoded
=== CONT  TestConfig_Update/PrivateKeyNotPEMEncoded
    --- PASS: TestConfig_Update/PrivateKeyNotPEMEncoded (0.00s)
=== RUN   TestConfig_Update/PrivateKeyInvalid
=== PAUSE TestConfig_Update/PrivateKeyInvalid
=== CONT  TestConfig_Update/PrivateKeyInvalid
    --- PASS: TestConfig_Update/PrivateKeyInvalid (0.00s)
=== RUN   TestBackend_PathConfigRead
=== PAUSE TestBackend_PathConfigRead
=== CONT  TestBackend_PathConfigRead
--- PASS: TestBackend_PathConfigRead (0.02s)
=== RUN   TestBackend_PathConfigRead/FieldValidation
=== PAUSE TestBackend_PathConfigRead/FieldValidation
=== CONT  TestBackend_PathConfigRead/FieldValidation
    --- PASS: TestBackend_PathConfigRead/FieldValidation (0.00s)
=== RUN   TestBackend_PathConfigRead/Empty
=== PAUSE TestBackend_PathConfigRead/Empty
=== CONT  TestBackend_PathConfigRead/Empty
    --- PASS: TestBackend_PathConfigRead/Empty (0.00s)
=== RUN   TestBackend_PathConfigRead/HappyPath
=== PAUSE TestBackend_PathConfigRead/HappyPath
=== CONT  TestBackend_PathConfigRead/HappyPath
    --- PASS: TestBackend_PathConfigRead/HappyPath (0.00s)
=== RUN   TestBackend_PathConfigRead/FailedStorage
=== PAUSE TestBackend_PathConfigRead/FailedStorage
=== CONT  TestBackend_PathConfigRead/FailedStorage
    --- PASS: TestBackend_PathConfigRead/FailedStorage (0.00s)
=== RUN   TestBackend_PathConfigCreate
=== PAUSE TestBackend_PathConfigCreate
=== CONT  TestBackend_PathConfigCreate
--- PASS: TestBackend_PathConfigCreate (0.06s)
=== RUN   TestBackend_PathConfigCreate/FailedValidation
=== PAUSE TestBackend_PathConfigCreate/FailedValidation
=== CONT  TestBackend_PathConfigCreate/FailedValidation
    --- PASS: TestBackend_PathConfigCreate/FailedValidation (0.00s)
=== RUN   TestBackend_PathConfigCreate/Empty
=== PAUSE TestBackend_PathConfigCreate/Empty
=== CONT  TestBackend_PathConfigCreate/Empty
    --- PASS: TestBackend_PathConfigCreate/Empty (0.00s)
=== RUN   TestBackend_PathConfigCreate/ExistInstallation
=== PAUSE TestBackend_PathConfigCreate/ExistInstallation
=== CONT  TestBackend_PathConfigCreate/ExistInstallation
    --- PASS: TestBackend_PathConfigCreate/ExistInstallation (0.00s)
=== RUN   TestBackend_PathConfigCreate/ExistOrganization
=== PAUSE TestBackend_PathConfigCreate/ExistOrganization
=== CONT  TestBackend_PathConfigCreate/ExistOrganization
    --- PASS: TestBackend_PathConfigCreate/ExistOrganization (0.00s)
=== RUN   TestBackend_PathConfigCreate/FailedStorageRetrieve
=== PAUSE TestBackend_PathConfigCreate/FailedStorageRetrieve
=== CONT  TestBackend_PathConfigCreate/FailedStorageRetrieve
    --- PASS: TestBackend_PathConfigCreate/FailedStorageRetrieve (0.00s)
=== RUN   TestBackend_PathConfigCreate/FailedStoragePersistInstallation
=== PAUSE TestBackend_PathConfigCreate/FailedStoragePersistInstallation
=== CONT  TestBackend_PathConfigCreate/FailedStoragePersistInstallation
    --- PASS: TestBackend_PathConfigCreate/FailedStoragePersistInstallation (0.00s)
=== RUN   TestBackend_PathConfigCreate/FailedStoragePersistOrganization
=== PAUSE TestBackend_PathConfigCreate/FailedStoragePersistOrganization
=== CONT  TestBackend_PathConfigCreate/FailedStoragePersistOrganization
    --- PASS: TestBackend_PathConfigCreate/FailedStoragePersistOrganization (0.01s)
=== RUN   TestBackend_PathConfigCreate/FailedValidation#01
=== PAUSE TestBackend_PathConfigCreate/FailedValidation#01
=== CONT  TestBackend_PathConfigCreate/FailedValidation#01
    --- PASS: TestBackend_PathConfigCreate/FailedValidation#01 (0.00s)
=== RUN   TestBackend_PathConfigUpdate
=== PAUSE TestBackend_PathConfigUpdate
=== CONT  TestBackend_PathConfigUpdate
--- PASS: TestBackend_PathConfigUpdate (0.02s)
=== RUN   TestBackend_PathConfigUpdate/FailedValidation
=== PAUSE TestBackend_PathConfigUpdate/FailedValidation
=== CONT  TestBackend_PathConfigUpdate/FailedValidation
    --- PASS: TestBackend_PathConfigUpdate/FailedValidation (0.00s)
=== RUN   TestBackend_PathConfigUpdate/Empty
=== PAUSE TestBackend_PathConfigUpdate/Empty
=== CONT  TestBackend_PathConfigUpdate/Empty
    --- PASS: TestBackend_PathConfigUpdate/Empty (0.00s)
=== RUN   TestBackend_PathConfigUpdate/ExistOrganization
=== PAUSE TestBackend_PathConfigUpdate/ExistOrganization
=== CONT  TestBackend_PathConfigUpdate/ExistOrganization
    --- PASS: TestBackend_PathConfigUpdate/ExistOrganization (0.01s)
=== RUN   TestBackend_PathConfigUpdate/ExistInstallation
=== PAUSE TestBackend_PathConfigUpdate/ExistInstallation
=== CONT  TestBackend_PathConfigUpdate/ExistInstallation
    --- PASS: TestBackend_PathConfigUpdate/ExistInstallation (0.00s)
=== RUN   TestBackend_PathConfigUpdate/FailedStorageRetrieve
=== PAUSE TestBackend_PathConfigUpdate/FailedStorageRetrieve
=== CONT  TestBackend_PathConfigUpdate/FailedStorageRetrieve
    --- PASS: TestBackend_PathConfigUpdate/FailedStorageRetrieve (0.00s)
=== RUN   TestBackend_PathConfigUpdate/FailedStoragePersistInstallation
=== PAUSE TestBackend_PathConfigUpdate/FailedStoragePersistInstallation
=== CONT  TestBackend_PathConfigUpdate/FailedStoragePersistInstallation
    --- PASS: TestBackend_PathConfigUpdate/FailedStoragePersistInstallation (0.00s)
=== RUN   TestBackend_PathConfigUpdate/FailedStoragePersistOrganization
=== PAUSE TestBackend_PathConfigUpdate/FailedStoragePersistOrganization
=== CONT  TestBackend_PathConfigUpdate/FailedStoragePersistOrganization
    --- PASS: TestBackend_PathConfigUpdate/FailedStoragePersistOrganization (0.00s)
=== RUN   TestBackend_PathConfigUpdate/FailedValidation#01
=== PAUSE TestBackend_PathConfigUpdate/FailedValidation#01
=== CONT  TestBackend_PathConfigUpdate/FailedValidation#01
    --- PASS: TestBackend_PathConfigUpdate/FailedValidation#01 (0.00s)
=== RUN   TestBackend_PathConfigDelete
=== PAUSE TestBackend_PathConfigDelete
=== CONT  TestBackend_PathConfigDelete
--- PASS: TestBackend_PathConfigDelete (0.02s)
=== RUN   TestBackend_PathConfigDelete/FieldValidation
=== PAUSE TestBackend_PathConfigDelete/FieldValidation
=== CONT  TestBackend_PathConfigDelete/FieldValidation
    --- PASS: TestBackend_PathConfigDelete/FieldValidation (0.00s)
=== RUN   TestBackend_PathConfigDelete/Empty
=== PAUSE TestBackend_PathConfigDelete/Empty
=== CONT  TestBackend_PathConfigDelete/Empty
    --- PASS: TestBackend_PathConfigDelete/Empty (0.00s)
=== RUN   TestBackend_PathConfigDelete/HappyPath
=== PAUSE TestBackend_PathConfigDelete/HappyPath
=== CONT  TestBackend_PathConfigDelete/HappyPath
    --- PASS: TestBackend_PathConfigDelete/HappyPath (0.00s)
=== RUN   TestBackend_PathConfigDelete/FailedStorage
=== PAUSE TestBackend_PathConfigDelete/FailedStorage
=== CONT  TestBackend_PathConfigDelete/FailedStorage
    --- PASS: TestBackend_PathConfigDelete/FailedStorage (0.00s)
=== RUN   TestBackend_PathInfoRead
=== PAUSE TestBackend_PathInfoRead
=== CONT  TestBackend_PathInfoRead
--- PASS: TestBackend_PathInfoRead (0.00s)
=== RUN   TestBackend_PathMetricsRead
=== PAUSE TestBackend_PathMetricsRead
=== CONT  TestBackend_PathMetricsRead
--- PASS: TestBackend_PathMetricsRead (0.02s)
=== RUN   TestBackend_PathMetricsRead/HappyPath
    --- PASS: TestBackend_PathMetricsRead/HappyPath (0.00s)
=== RUN   TestBackend_PathMetricsRead/NoMetrics
    --- PASS: TestBackend_PathMetricsRead/NoMetrics (0.00s)
=== RUN   TestBackend_PermissionSet
=== PAUSE TestBackend_PermissionSet
=== CONT  TestBackend_PermissionSet
--- PASS: TestBackend_PermissionSet (0.00s)
=== RUN   TestBackend_PermissionSet/ValidateNameEmpty
=== PAUSE TestBackend_PermissionSet/ValidateNameEmpty
=== CONT  TestBackend_PermissionSet/ValidateNameEmpty
    --- PASS: TestBackend_PermissionSet/ValidateNameEmpty (0.00s)
=== RUN   TestBackend_PermissionSet/ValidateTokenOptionEmpty
=== PAUSE TestBackend_PermissionSet/ValidateTokenOptionEmpty
=== CONT  TestBackend_PermissionSet/ValidateTokenOptionEmpty
    --- PASS: TestBackend_PermissionSet/ValidateTokenOptionEmpty (0.00s)
=== RUN   TestBackend_PermissionSet/FailSave
=== PAUSE TestBackend_PermissionSet/FailSave
=== CONT  TestBackend_PermissionSet/FailSave
    --- PASS: TestBackend_PermissionSet/FailSave (0.00s)
=== RUN   TestBackend_PermissionSet/ValidateGetPermissionSet
=== PAUSE TestBackend_PermissionSet/ValidateGetPermissionSet
=== CONT  TestBackend_PermissionSet/ValidateGetPermissionSet
    --- PASS: TestBackend_PermissionSet/ValidateGetPermissionSet (0.00s)
=== RUN   TestBackend_PathPermissionSetRead
=== PAUSE TestBackend_PathPermissionSetRead
=== CONT  TestBackend_PathPermissionSetRead
--- PASS: TestBackend_PathPermissionSetRead (0.00s)
=== RUN   TestBackend_PathPermissionSetRead/HappyPath
=== PAUSE TestBackend_PathPermissionSetRead/HappyPath
=== CONT  TestBackend_PathPermissionSetRead/HappyPath
    --- PASS: TestBackend_PathPermissionSetRead/HappyPath (0.00s)
=== RUN   TestBackend_PathPermissionSetRead/NonExistenceCheck
=== PAUSE TestBackend_PathPermissionSetRead/NonExistenceCheck
=== CONT  TestBackend_PathPermissionSetRead/NonExistenceCheck
    --- PASS: TestBackend_PathPermissionSetRead/NonExistenceCheck (0.00s)
=== RUN   TestBackend_PathPermissionSetRead/ReadFail
=== PAUSE TestBackend_PathPermissionSetRead/ReadFail
=== CONT  TestBackend_PathPermissionSetRead/ReadFail
    --- PASS: TestBackend_PathPermissionSetRead/ReadFail (0.00s)
=== RUN   TestBackend_PathPermissionSetDelete
=== PAUSE TestBackend_PathPermissionSetDelete
=== CONT  TestBackend_PathPermissionSetDelete
--- PASS: TestBackend_PathPermissionSetDelete (0.00s)
=== RUN   TestBackend_PathPermissionSetDelete/HappyPath
=== PAUSE TestBackend_PathPermissionSetDelete/HappyPath
=== CONT  TestBackend_PathPermissionSetDelete/HappyPath
    --- PASS: TestBackend_PathPermissionSetDelete/HappyPath (0.01s)
=== RUN   TestBackend_PathPermissionSetDelete/DeleteNonExistent
=== PAUSE TestBackend_PathPermissionSetDelete/DeleteNonExistent
=== CONT  TestBackend_PathPermissionSetDelete/DeleteNonExistent
    --- PASS: TestBackend_PathPermissionSetDelete/DeleteNonExistent (0.00s)
=== RUN   TestBackend_PathPermissionSetDelete/DeleteFail
=== PAUSE TestBackend_PathPermissionSetDelete/DeleteFail
=== CONT  TestBackend_PathPermissionSetDelete/DeleteFail
    --- PASS: TestBackend_PathPermissionSetDelete/DeleteFail (0.00s)
=== RUN   TestBackend_PathPermissionSetWriteCreate
=== PAUSE TestBackend_PathPermissionSetWriteCreate
=== CONT  TestBackend_PathPermissionSetWriteCreate
--- PASS: TestBackend_PathPermissionSetWriteCreate (0.00s)
=== RUN   TestBackend_PathPermissionSetWriteCreate/HappyPath
=== PAUSE TestBackend_PathPermissionSetWriteCreate/HappyPath
=== CONT  TestBackend_PathPermissionSetWriteCreate/HappyPath
    --- PASS: TestBackend_PathPermissionSetWriteCreate/HappyPath (0.00s)
=== RUN   TestBackend_PathPermissionSetWriteCreate/CreateFail
=== PAUSE TestBackend_PathPermissionSetWriteCreate/CreateFail
=== CONT  TestBackend_PathPermissionSetWriteCreate/CreateFail
    --- PASS: TestBackend_PathPermissionSetWriteCreate/CreateFail (0.00s)
=== RUN   TestBackend_PathPermissionSetWriteUpdate
=== PAUSE TestBackend_PathPermissionSetWriteUpdate
=== CONT  TestBackend_PathPermissionSetWriteUpdate
--- PASS: TestBackend_PathPermissionSetWriteUpdate (0.03s)
=== RUN   TestBackend_PathPermissionSetWriteUpdate/HappyPath
=== PAUSE TestBackend_PathPermissionSetWriteUpdate/HappyPath
=== CONT  TestBackend_PathPermissionSetWriteUpdate/HappyPath
    --- PASS: TestBackend_PathPermissionSetWriteUpdate/HappyPath (0.00s)
=== RUN   TestBackend_PathPermissionSetWriteUpdate/CreateFail
=== PAUSE TestBackend_PathPermissionSetWriteUpdate/CreateFail
=== CONT  TestBackend_PathPermissionSetWriteUpdate/CreateFail
    --- PASS: TestBackend_PathPermissionSetWriteUpdate/CreateFail (0.01s)
=== RUN   TestBackend_PathPermissionSetList
=== PAUSE TestBackend_PathPermissionSetList
=== CONT  TestBackend_PathPermissionSetList
--- PASS: TestBackend_PathPermissionSetList (0.00s)
=== RUN   TestBackend_PathPermissionSetList/HappyPath
=== PAUSE TestBackend_PathPermissionSetList/HappyPath
=== CONT  TestBackend_PathPermissionSetList/HappyPath
    --- PASS: TestBackend_PathPermissionSetList/HappyPath (0.00s)
=== RUN   TestBackend_PathPermissionSetList/ListFail
=== PAUSE TestBackend_PathPermissionSetList/ListFail
=== CONT  TestBackend_PathPermissionSetList/ListFail
    --- PASS: TestBackend_PathPermissionSetList/ListFail (0.00s)
=== RUN   TestPathValidateFields
=== PAUSE TestPathValidateFields
=== CONT  TestPathValidateFields
--- PASS: TestPathValidateFields (0.03s)
=== RUN   TestPathValidateFields/HappyPath
=== PAUSE TestPathValidateFields/HappyPath
=== CONT  TestPathValidateFields/HappyPath
    --- PASS: TestPathValidateFields/HappyPath (0.00s)
=== RUN   TestPathValidateFields/Empty
=== PAUSE TestPathValidateFields/Empty
=== CONT  TestPathValidateFields/Empty
    --- PASS: TestPathValidateFields/Empty (0.00s)
=== RUN   TestPathValidateFields/UnknownField
=== PAUSE TestPathValidateFields/UnknownField
=== CONT  TestPathValidateFields/UnknownField
    --- PASS: TestPathValidateFields/UnknownField (0.00s)
=== RUN   TestPathValidateFields/UnknownFields
=== PAUSE TestPathValidateFields/UnknownFields
=== CONT  TestPathValidateFields/UnknownFields
    --- PASS: TestPathValidateFields/UnknownFields (0.00s)
=== RUN   TestBackend_PathTokenPermissionSetWriteCreate
=== PAUSE TestBackend_PathTokenPermissionSetWriteCreate
=== CONT  TestBackend_PathTokenPermissionSetWriteCreate
--- PASS: TestBackend_PathTokenPermissionSetWriteCreate (0.00s)
=== RUN   TestBackend_PathTokenPermissionSetWriteCreate/FailedValidation
=== PAUSE TestBackend_PathTokenPermissionSetWriteCreate/FailedValidation
=== CONT  TestBackend_PathTokenPermissionSetWriteCreate/FailedValidation
    --- PASS: TestBackend_PathTokenPermissionSetWriteCreate/FailedValidation (0.00s)
=== RUN   TestBackend_PathTokenPermissionSetWriteCreate/HappyPath
=== PAUSE TestBackend_PathTokenPermissionSetWriteCreate/HappyPath
=== CONT  TestBackend_PathTokenPermissionSetWriteCreate/HappyPath
    --- PASS: TestBackend_PathTokenPermissionSetWriteCreate/HappyPath (0.01s)
=== RUN   TestBackend_PathTokenPermissionSetWriteCreate/FailedClient
=== PAUSE TestBackend_PathTokenPermissionSetWriteCreate/FailedClient
=== CONT  TestBackend_PathTokenPermissionSetWriteCreate/FailedClient
    --- PASS: TestBackend_PathTokenPermissionSetWriteCreate/FailedClient (0.00s)
=== RUN   TestBackend_PathTokenPermissionSetWriteCreate/FailedCreate
=== PAUSE TestBackend_PathTokenPermissionSetWriteCreate/FailedCreate
=== CONT  TestBackend_PathTokenPermissionSetWriteCreate/FailedCreate
    --- PASS: TestBackend_PathTokenPermissionSetWriteCreate/FailedCreate (0.00s)
=== RUN   TestBackend_PathTokenPermissionSetWriteUpdate
=== PAUSE TestBackend_PathTokenPermissionSetWriteUpdate
=== CONT  TestBackend_PathTokenPermissionSetWriteUpdate
--- PASS: TestBackend_PathTokenPermissionSetWriteUpdate (0.03s)
=== RUN   TestBackend_PathTokenPermissionSetWriteUpdate/FailedValidation
=== PAUSE TestBackend_PathTokenPermissionSetWriteUpdate/FailedValidation
=== CONT  TestBackend_PathTokenPermissionSetWriteUpdate/FailedValidation
    --- PASS: TestBackend_PathTokenPermissionSetWriteUpdate/FailedValidation (0.00s)
=== RUN   TestBackend_PathTokenPermissionSetWriteUpdate/HappyPath
=== PAUSE TestBackend_PathTokenPermissionSetWriteUpdate/HappyPath
=== CONT  TestBackend_PathTokenPermissionSetWriteUpdate/HappyPath
    --- PASS: TestBackend_PathTokenPermissionSetWriteUpdate/HappyPath (0.02s)
=== RUN   TestBackend_PathTokenPermissionSetWriteUpdate/FailedClient
=== PAUSE TestBackend_PathTokenPermissionSetWriteUpdate/FailedClient
=== CONT  TestBackend_PathTokenPermissionSetWriteUpdate/FailedClient
    --- PASS: TestBackend_PathTokenPermissionSetWriteUpdate/FailedClient (0.00s)
=== RUN   TestBackend_PathTokenPermissionSetWriteUpdate/FailedCreate
=== PAUSE TestBackend_PathTokenPermissionSetWriteUpdate/FailedCreate
=== CONT  TestBackend_PathTokenPermissionSetWriteUpdate/FailedCreate
    --- PASS: TestBackend_PathTokenPermissionSetWriteUpdate/FailedCreate (0.01s)
=== RUN   TestBackend_PathTokenWriteRead
=== PAUSE TestBackend_PathTokenWriteRead
=== CONT  TestBackend_PathTokenWriteRead
--- PASS: TestBackend_PathTokenWriteRead (0.00s)
=== RUN   TestBackend_PathTokenWriteRead/FailedValidation
=== PAUSE TestBackend_PathTokenWriteRead/FailedValidation
=== CONT  TestBackend_PathTokenWriteRead/FailedValidation
    --- PASS: TestBackend_PathTokenWriteRead/FailedValidation (0.00s)
=== RUN   TestBackend_PathTokenWriteRead/HappyPath
=== PAUSE TestBackend_PathTokenWriteRead/HappyPath
=== CONT  TestBackend_PathTokenWriteRead/HappyPath
    --- PASS: TestBackend_PathTokenWriteRead/HappyPath (0.03s)
=== RUN   TestBackend_PathTokenWriteRead/FailedClient
=== PAUSE TestBackend_PathTokenWriteRead/FailedClient
=== CONT  TestBackend_PathTokenWriteRead/FailedClient
    --- PASS: TestBackend_PathTokenWriteRead/FailedClient (0.00s)
=== RUN   TestBackend_PathTokenWriteRead/FailedOptionsParsing
=== PAUSE TestBackend_PathTokenWriteRead/FailedOptionsParsing
=== CONT  TestBackend_PathTokenWriteRead/FailedOptionsParsing
    --- PASS: TestBackend_PathTokenWriteRead/FailedOptionsParsing (0.00s)
=== RUN   TestBackend_PathTokenWriteRead/FailedCreate
=== PAUSE TestBackend_PathTokenWriteRead/FailedCreate
=== CONT  TestBackend_PathTokenWriteRead/FailedCreate
    --- PASS: TestBackend_PathTokenWriteRead/FailedCreate (0.01s)
=== RUN   TestBackend_PathTokenWriteRead/HappyPathOrgPlusOrg
=== PAUSE TestBackend_PathTokenWriteRead/HappyPathOrgPlusOrg
=== CONT  TestBackend_PathTokenWriteRead/HappyPathOrgPlusOrg
    --- PASS: TestBackend_PathTokenWriteRead/HappyPathOrgPlusOrg (0.01s)
=== RUN   TestBackend_PathTokenWriteCreate
=== PAUSE TestBackend_PathTokenWriteCreate
=== CONT  TestBackend_PathTokenWriteCreate
--- PASS: TestBackend_PathTokenWriteCreate (0.03s)
=== RUN   TestBackend_PathTokenWriteCreate/FailedValidation
=== PAUSE TestBackend_PathTokenWriteCreate/FailedValidation
=== CONT  TestBackend_PathTokenWriteCreate/FailedValidation
    --- PASS: TestBackend_PathTokenWriteCreate/FailedValidation (0.00s)
=== RUN   TestBackend_PathTokenWriteCreate/HappyPath
=== PAUSE TestBackend_PathTokenWriteCreate/HappyPath
=== CONT  TestBackend_PathTokenWriteCreate/HappyPath
    --- PASS: TestBackend_PathTokenWriteCreate/HappyPath (0.02s)
=== RUN   TestBackend_PathTokenWriteCreate/FailedClient
=== PAUSE TestBackend_PathTokenWriteCreate/FailedClient
=== CONT  TestBackend_PathTokenWriteCreate/FailedClient
    --- PASS: TestBackend_PathTokenWriteCreate/FailedClient (0.00s)
=== RUN   TestBackend_PathTokenWriteCreate/FailedOptionsParsing
=== PAUSE TestBackend_PathTokenWriteCreate/FailedOptionsParsing
=== CONT  TestBackend_PathTokenWriteCreate/FailedOptionsParsing
    --- PASS: TestBackend_PathTokenWriteCreate/FailedOptionsParsing (0.00s)
=== RUN   TestBackend_PathTokenWriteCreate/FailedCreate
=== PAUSE TestBackend_PathTokenWriteCreate/FailedCreate
=== CONT  TestBackend_PathTokenWriteCreate/FailedCreate
    --- PASS: TestBackend_PathTokenWriteCreate/FailedCreate (0.03s)
=== RUN   TestBackend_PathTokenWriteCreate/HappyPathOrgPlusOrg
=== PAUSE TestBackend_PathTokenWriteCreate/HappyPathOrgPlusOrg
=== CONT  TestBackend_PathTokenWriteCreate/HappyPathOrgPlusOrg
    --- PASS: TestBackend_PathTokenWriteCreate/HappyPathOrgPlusOrg (0.02s)
=== RUN   TestBackend_PathTokenWriteUpdate
=== PAUSE TestBackend_PathTokenWriteUpdate
=== CONT  TestBackend_PathTokenWriteUpdate
--- PASS: TestBackend_PathTokenWriteUpdate (0.03s)
=== RUN   TestBackend_PathTokenWriteUpdate/FailedValidation
=== PAUSE TestBackend_PathTokenWriteUpdate/FailedValidation
=== CONT  TestBackend_PathTokenWriteUpdate/FailedValidation
    --- PASS: TestBackend_PathTokenWriteUpdate/FailedValidation (0.00s)
=== RUN   TestBackend_PathTokenWriteUpdate/HappyPath
=== PAUSE TestBackend_PathTokenWriteUpdate/HappyPath
=== CONT  TestBackend_PathTokenWriteUpdate/HappyPath
    --- PASS: TestBackend_PathTokenWriteUpdate/HappyPath (0.02s)
=== RUN   TestBackend_PathTokenWriteUpdate/FailedClient
=== PAUSE TestBackend_PathTokenWriteUpdate/FailedClient
=== CONT  TestBackend_PathTokenWriteUpdate/FailedClient
    --- PASS: TestBackend_PathTokenWriteUpdate/FailedClient (0.00s)
=== RUN   TestBackend_PathTokenWriteUpdate/FailedOptionsParsing
=== PAUSE TestBackend_PathTokenWriteUpdate/FailedOptionsParsing
=== CONT  TestBackend_PathTokenWriteUpdate/FailedOptionsParsing
    --- PASS: TestBackend_PathTokenWriteUpdate/FailedOptionsParsing (0.00s)
=== RUN   TestBackend_PathTokenWriteUpdate/FailedCreate
=== PAUSE TestBackend_PathTokenWriteUpdate/FailedCreate
=== CONT  TestBackend_PathTokenWriteUpdate/FailedCreate
    --- PASS: TestBackend_PathTokenWriteUpdate/FailedCreate (0.02s)
=== RUN   TestBackend_PathTokenWriteUpdate/HappyPathOrgPlusOrg
=== PAUSE TestBackend_PathTokenWriteUpdate/HappyPathOrgPlusOrg
=== CONT  TestBackend_PathTokenWriteUpdate/HappyPathOrgPlusOrg
    --- PASS: TestBackend_PathTokenWriteUpdate/HappyPathOrgPlusOrg (0.02s)
=== RUN   TestBackend_Revoke
=== PAUSE TestBackend_Revoke
=== CONT  TestBackend_Revoke
--- PASS: TestBackend_Revoke (0.06s)
=== RUN   TestBackend_Revoke/HappyPath
=== PAUSE TestBackend_Revoke/HappyPath
=== CONT  TestBackend_Revoke/HappyPath
    --- PASS: TestBackend_Revoke/HappyPath (0.00s)
=== RUN   TestBackend_Revoke/FailedClient
=== PAUSE TestBackend_Revoke/FailedClient
=== CONT  TestBackend_Revoke/FailedClient
    --- PASS: TestBackend_Revoke/FailedClient (0.00s)
=== RUN   TestBackend_Revoke/FailedOptionsParsing
=== PAUSE TestBackend_Revoke/FailedOptionsParsing
=== CONT  TestBackend_Revoke/FailedOptionsParsing
    --- PASS: TestBackend_Revoke/FailedOptionsParsing (0.00s)
=== RUN   TestBackend_Revoke/FailedRevoke
=== PAUSE TestBackend_Revoke/FailedRevoke
=== CONT  TestBackend_Revoke/FailedRevoke
    --- PASS: TestBackend_Revoke/FailedRevoke (0.00s)
PASS
ok  	github.com/martinbaillie/vault-plugin-secrets-github/github	0.670s

Process finished with the exit code 0
```